### PR TITLE
Load script on load  and not inline

### DIFF
--- a/assets/js/onload.js
+++ b/assets/js/onload.js
@@ -1,4 +1,8 @@
 window.onload = () => {
   swiperInit();
   mobileNavBarInit();
+
+  let script = document.createElement("script");
+  script.src = "https://assets.calendly.com/assets/external/widget.js";
+  document.body.append(script);
 };

--- a/index.html
+++ b/index.html
@@ -388,7 +388,7 @@ permalink: /
          data-url="https://calendly.com/gbergere/intro?hide_landing_page_details=1&hide_gdpr_banner=1&primary_color=1E85C2"
          style="min-width:320px;width:100%;height:700px;">
     </div>
-    <script type="text/javascript" src="https://assets.calendly.com/assets/external/widget.js" async></script>
+
     <!-- Calendly inline widget end -->
   </div>
 </div></div>


### PR DESCRIPTION
It seems even script async in the header doesn't change shit. 
But it seems to load "manually" works, I guess the scroll thinks all is loaded, even if it is still loading more scripts